### PR TITLE
Swap University names

### DIFF
--- a/source/_about.html.slim
+++ b/source/_about.html.slim
@@ -13,7 +13,7 @@ section#about
           time datetime="2018-06-12"  4
           |  -
           time datetime="2018-06-13"  5
-          |  Junho 2019, Universidade do Porto
+          |  Junho 2019, Universidade do Minho
         h4 Evento anual que visa promover a interação entre os alunos dos cursos de três ciclos de estudos desta universidade com uma forte componente de informática e o meio empresarial, regional ou nacional, que tem sido a sua maior força empregadora.
         br/
         .span1


### PR DESCRIPTION
Wrongly written as 'Porto', now fixed to 'Minho'